### PR TITLE
fix: improve mobile rendering for posts

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -563,7 +563,7 @@ def blog_post(slug: str) -> None:
                     )
 
             # Article content with improved styling
-            ui.html(post["content"]).classes("blog-content prose prose-lg max-w-none")
+            ui.html(post["content"]).classes("blog-content prose prose-lg")
 
             # Article footer with tags and sharing
             with ui.row().classes(

--- a/static/blog.css
+++ b/static/blog.css
@@ -31,6 +31,7 @@
             line-height: var(--pico-line-height);
             background-color: var(--dark-bg);
             color: var(--text-primary);
+            overflow-x: hidden;
         }
 
         code, pre, .highlight {
@@ -124,8 +125,10 @@
         }
 
         .blog-content {
-            max-width: none;
+            max-width: 100%;
+            width: 100%;
             line-height: 1.7;
+            overflow-wrap: anywhere;
         }
 
         .blog-content h1, .blog-content h2, .blog-content h3,


### PR DESCRIPTION
## Summary
- make blog posts responsive on mobile by limiting content width and wrapping long text
- hide horizontal overflow to keep dark theme consistent

## Testing
- `uv run ruff format . && uv run ruff check . --fix`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_688db1276c4c832b9c71ed2d410004c8