### PR TITLE
Add time metadata for post sorting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@ Markdown posts use YAML frontmatter:
 ---
 title: "Post Title"
 date: "8/1/2025"
+time: "03:12"
 summary: "Brief description"
 tags: ["tag1", "tag2"]
 ---

--- a/app/content.py
+++ b/app/content.py
@@ -153,8 +153,22 @@ def get_all_posts() -> list[dict[str, Any]]:
             metadata["word_count"] = len(content.split())
             metadata["read_time"] = max(1, metadata["word_count"] // 200)
 
-            # Always use the file's last modified time for dates
-            metadata["date"] = get_last_modified(md_file)
+            # Combine provided date and time for sorting, fallback to file mtime
+            date_str = metadata.get("date")
+            time_str = metadata.get("time")
+            if date_str:
+                try:
+                    fmt = "%m/%d/%Y"
+                    if time_str:
+                        metadata["date"] = datetime.strptime(
+                            f"{date_str} {time_str}", f"{fmt} %H:%M"
+                        )
+                    else:
+                        metadata["date"] = datetime.strptime(date_str, fmt)
+                except ValueError:
+                    metadata["date"] = get_last_modified(md_file)
+            else:
+                metadata["date"] = get_last_modified(md_file)
 
             posts.append(metadata)
 
@@ -346,8 +360,22 @@ def get_post_by_slug(slug: str) -> dict[str, Any] | None:
         metadata["word_count"] = len(content_text.split())
         metadata["read_time"] = max(1, metadata["word_count"] // 200)
 
-        # Always use the file's last modified time for dates
-        metadata["date"] = get_last_modified(matching_file)
+        # Combine provided date and time for sorting, fallback to file mtime
+        date_str = metadata.get("date")
+        time_str = metadata.get("time")
+        if date_str:
+            try:
+                fmt = "%m/%d/%Y"
+                if time_str:
+                    metadata["date"] = datetime.strptime(
+                        f"{date_str} {time_str}", f"{fmt} %H:%M"
+                    )
+                else:
+                    metadata["date"] = datetime.strptime(date_str, fmt)
+            except ValueError:
+                metadata["date"] = get_last_modified(matching_file)
+        else:
+            metadata["date"] = get_last_modified(matching_file)
 
         result = {
             "slug": slug,

--- a/content/posts/building-with-nicegui.md
+++ b/content/posts/building-with-nicegui.md
@@ -1,8 +1,16 @@
 ---
-title: "Building Modern Web Apps with NiceGUI v2.22.1"
-date: "8/15/2025"
-summary: "A tour of NiceGUI's Python-centric approach to building feature-rich web applications without touching JavaScript."
-tags: ["nicegui", "python", "web-development", "ui", "framework", "tutorial"]
+title: Building Modern Web Apps with NiceGUI v2.22.1
+date: 8/2/2025
+time: 03:08
+summary: A tour of NiceGUI's Python-centric approach to building feature-rich web
+  applications without touching JavaScript.
+tags:
+- nicegui
+- python
+- web-development
+- ui
+- framework
+- tutorial
 ---
 
 # Building Web Apps with NiceGUI

--- a/content/posts/caching-nicegui-with-ttlcache.md
+++ b/content/posts/caching-nicegui-with-ttlcache.md
@@ -1,8 +1,14 @@
 ---
-title: "Boosting NiceGUI Performance with TTLCache"
-date: "8/20/2025"
-summary: "Speed up repeated NiceGUI computations by storing results in cachetools.TTLCache."
-tags: ["nicegui", "cache", "performance", "python", "tutorial"]
+title: Boosting NiceGUI Performance with TTLCache
+date: 8/2/2025
+time: 03:07
+summary: Speed up repeated NiceGUI computations by storing results in cachetools.TTLCache.
+tags:
+- nicegui
+- cache
+- performance
+- python
+- tutorial
 ---
 
 # Boosting NiceGUI Performance with TTLCache

--- a/content/posts/dark-mode-dashboard-with-nicegui.md
+++ b/content/posts/dark-mode-dashboard-with-nicegui.md
@@ -1,8 +1,14 @@
 ---
-title: "Designing a Dark Mode Dashboard with NiceGUI"
-date: "8/10/2025"
-summary: "Create a sleek dark-themed dashboard using NiceGUI, Pico.css, and Python." 
-tags: ["nicegui", "dashboard", "dark-mode", "ui", "tutorial"]
+title: Designing a Dark Mode Dashboard with NiceGUI
+date: 8/2/2025
+time: 03:06
+summary: Create a sleek dark-themed dashboard using NiceGUI, Pico.css, and Python.
+tags:
+- nicegui
+- dashboard
+- dark-mode
+- ui
+- tutorial
 ---
 
 # Designing a Dark Mode Dashboard

--- a/content/posts/deploying-nicegui-with-docker.md
+++ b/content/posts/deploying-nicegui-with-docker.md
@@ -1,8 +1,14 @@
 ---
-title: "Deploying NiceGUI with Docker"
-date: "8/25/2025"
-summary: "Package and run NiceGUI applications in lightweight Docker containers using modern Python tooling." 
-tags: ["nicegui", "docker", "deployment", "tutorial"]
+title: Deploying NiceGUI with Docker
+date: 8/2/2025
+time: 03:10
+summary: Package and run NiceGUI applications in lightweight Docker containers using
+  modern Python tooling.
+tags:
+- nicegui
+- docker
+- deployment
+- tutorial
 ---
 
 # Deploying NiceGUI with Docker

--- a/content/posts/micro-interactions-with-nicegui.md
+++ b/content/posts/micro-interactions-with-nicegui.md
@@ -1,8 +1,13 @@
 ---
-title: "Tiny Touches: Micro-Interactions in NiceGUI"
-date: "8/8/2025"
-summary: "Add playful animations and feedback to make your NiceGUI apps feel alive."
-tags: ["nicegui", "ui", "animations", "tips"]
+title: 'Tiny Touches: Micro-Interactions in NiceGUI'
+date: 8/2/2025
+time: 03:05
+summary: Add playful animations and feedback to make your NiceGUI apps feel alive.
+tags:
+- nicegui
+- ui
+- animations
+- tips
 ---
 
 # Tiny Touches: Micro-Interactions in NiceGUI

--- a/content/posts/python-tips-and-tricks.md
+++ b/content/posts/python-tips-and-tricks.md
@@ -1,8 +1,15 @@
 ---
-title: "Python 3.13 Tips and Tricks for Better Code"
-date: "8/5/2025"
-summary: "Fifteen practical Python 3.13 techniques for cleaner, more efficient code."
-tags: ["python", "tips", "best-practices", "python313", "coding", "tutorial"]
+title: Python 3.13 Tips and Tricks for Better Code
+date: 8/2/2025
+time: 03:04
+summary: Fifteen practical Python 3.13 techniques for cleaner, more efficient code.
+tags:
+- python
+- tips
+- best-practices
+- python313
+- coding
+- tutorial
 ---
 
 # Python Tips and Tricks for Better Code

--- a/content/posts/styling-nicegui-with-picocss.md
+++ b/content/posts/styling-nicegui-with-picocss.md
@@ -1,8 +1,15 @@
 ---
-title: "Styling NiceGUI with Pico.css"
-date: "8/12/2025"
-summary: "Enhance NiceGUI interfaces with Pico.css, global CSS variables, and component classes." 
-tags: ["nicegui", "css", "pico", "styling", "tutorial"]
+title: Styling NiceGUI with Pico.css
+date: 8/2/2025
+time: 03:03
+summary: Enhance NiceGUI interfaces with Pico.css, global CSS variables, and component
+  classes.
+tags:
+- nicegui
+- css
+- pico
+- styling
+- tutorial
 ---
 
 # Styling NiceGUI with Pico.css

--- a/content/posts/testing-nicegui-with-pytest.md
+++ b/content/posts/testing-nicegui-with-pytest.md
@@ -1,8 +1,14 @@
 ---
-title: "Bulletproof NiceGUI: Testing with Pytest"
-date: "9/1/2025"
-summary: "Learn how to verify your NiceGUI pages and utilities using pytest and a few handy helpers."
-tags: ["nicegui", "pytest", "testing", "python"]
+title: 'Bulletproof NiceGUI: Testing with Pytest'
+date: 8/2/2025
+time: 03:11
+summary: Learn how to verify your NiceGUI pages and utilities using pytest and a few
+  handy helpers.
+tags:
+- nicegui
+- pytest
+- testing
+- python
 ---
 
 # Bulletproof NiceGUI: Testing with Pytest

--- a/content/posts/under-the-hood-tech-stack.md
+++ b/content/posts/under-the-hood-tech-stack.md
@@ -1,8 +1,14 @@
 ---
-title: "Under the Hood: Powering the NiceGUI Blog"
-date: "9/10/2025"
-summary: "Explore the full stack—from Python and NiceGUI to caching, styling, and build tools—that keeps this blog humming."
-tags: ["nicegui", "tech-stack", "python", "blog"]
+title: 'Under the Hood: Powering the NiceGUI Blog'
+date: 8/2/2025
+time: 03:12
+summary: Explore the full stack—from Python and NiceGUI to caching, styling, and build
+  tools—that keeps this blog humming.
+tags:
+- nicegui
+- tech-stack
+- python
+- blog
 ---
 
 # Under the Hood: Powering the NiceGUI Blog

--- a/content/posts/welcome-to-my-blog.md
+++ b/content/posts/welcome-to-my-blog.md
@@ -1,8 +1,15 @@
 ---
-title: "Welcome to My Modern NiceGUI Blog"
-date: "8/1/2025"
-summary: "An introduction to a lightning-fast NiceGUI blog built with a dark theme, caching, and modern Python tooling." 
-tags: ["nicegui", "python", "web-development", "blog", "tutorial"]
+title: Welcome to My Modern NiceGUI Blog
+date: 8/2/2025
+time: 03:09
+summary: An introduction to a lightning-fast NiceGUI blog built with a dark theme,
+  caching, and modern Python tooling.
+tags:
+- nicegui
+- python
+- web-development
+- blog
+- tutorial
 ---
 
 # Welcome

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -1,8 +1,6 @@
 """Tests for content management utilities."""
 
-import os
 import sys
-from datetime import datetime
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -61,20 +59,21 @@ def test_get_post_by_slug_sanitizes_html(tmp_path: Path) -> None:
         test_file.unlink(missing_ok=True)
 
 
-def test_dates_use_file_mtime(tmp_path: Path, monkeypatch) -> None:
-    """Post dates should reflect the file's last modified time."""
+def test_posts_sorted_by_frontmatter_time(tmp_path: Path, monkeypatch) -> None:
+    """Posts should be ordered by frontmatter date and time."""
     posts_dir = tmp_path / "content" / "posts"
     posts_dir.mkdir(parents=True)
-    md = posts_dir / "sample.md"
-    md.write_text(
-        "---\ntitle: Sample\ndate: 1/1/2000\n---\ncontent",
+    first = posts_dir / "first.md"
+    second = posts_dir / "second.md"
+    first.write_text(
+        "---\ntitle: First\ndate: 8/2/2025\ntime: 03:12\n---\ncontent",
         encoding="utf-8",
     )
-    mtime = 1_700_000_000
-    os.utime(md, (mtime, mtime))
+    second.write_text(
+        "---\ntitle: Second\ndate: 8/2/2025\ntime: 02:00\n---\ncontent",
+        encoding="utf-8",
+    )
     monkeypatch.chdir(tmp_path)
     posts = get_all_posts()
-    assert posts[0]["date"] == datetime.fromtimestamp(mtime)
-    post = get_post_by_slug("sample")
-    assert post is not None
-    assert post["date"] == datetime.fromtimestamp(mtime)
+    assert posts[0]["slug"] == "first"
+    assert posts[1]["slug"] == "second"


### PR DESCRIPTION
## Summary
- add `time` field to post frontmatter and document it
- sort posts by combined date and time instead of file mtime
- verify ordering by frontmatter in tests